### PR TITLE
allow for stars in input file name

### DIFF
--- a/ovitoclient/ovitoclient.py
+++ b/ovitoclient/ovitoclient.py
@@ -21,6 +21,7 @@ from PyQt5 import QtCore
 import argparse
 import os
 
+
 IMAGE_TYPES = ['png', 'jpg', 'jpeg', 'tif', 'tiff']
 MOVIE_TYPES = ['gif', 'avi', 'mov', 'mp4']
 ALL_OUTPUT_TYPES = IMAGE_TYPES + MOVIE_TYPES
@@ -82,6 +83,7 @@ def main(args):
 
 def add_output_path(args):
     args.input_file = os.path.abspath(args.input_file)
+    args.input_file = args.input_file.replace('\\*', '*')
     input_ext = args.input_file.split('.')[-1]
     if args.output_file is None:
         args.output_file = (
@@ -98,6 +100,7 @@ def add_output_path(args):
                 ".{} is not a valid output extension.\n".format(args.output_ext)
                 + "Accepted extensions: {}".format(ALL_OUTPUT_TYPES)
             )
+
 
 def add_custom_range(args):
     if args.custom_range is None:


### PR DESCRIPTION
Allows for multiple input files if they only differ by a number in the name, and `\*` replaces those numbers, like

```
ovitoclient 'trajectory_\*.lammpstrj'
```

where you're  a directory with e.g. `trajectory_0000.lammpstrj`, `trajectory_0001.lammpstrj`, and `trajectory_0002.lammpstrj`.